### PR TITLE
Added some simple server side session management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Flask session
+flask_session

--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 from datetime import date
-from flask import Flask, url_for, render_template, request
+from flask import Flask, url_for, render_template, request, session
+from flask_session import Session
 from functools import wraps
+
 
 from kinde_sdk import Configuration
 from kinde_sdk.kinde_api_client import GrantType, KindeApiClient
@@ -8,6 +10,7 @@ from kinde_sdk.kinde_api_client import GrantType, KindeApiClient
 
 app = Flask(__name__)
 app.config.from_object("config")
+Session(app)
 
 configuration = Configuration(host=app.config["KINDE_ISSUER_URL"])
 kinde_api_client_params = {
@@ -22,11 +25,12 @@ if app.config["GRANT_TYPE"] == GrantType.AUTHORIZATION_CODE_WITH_PKCE:
     kinde_api_client_params["code_verifier"] = app.config["CODE_VERIFIER"]
 
 kinde_client = KindeApiClient(**kinde_api_client_params)
-
+user_clients = {}
 
 def get_authorized_data(kinde_client):
     user = kinde_client.get_user_details()
     return {
+        "id": user.get("id"),
         "user_given_name": user.get("given_name"),
         "user_family_name": user.get("family_name"),
         "user_email": user.get("email"),
@@ -49,9 +53,11 @@ def login_required(user):
 def index():
     data = {"current_year": date.today().year}
     template = "logged_out.html"
-    if kinde_client.is_authenticated():
-        data.update(get_authorized_data(kinde_client))        
-        template = "home.html"
+    if session.get("user"):
+        kinde_client = user_clients.get(session.get("user"))
+        if kinde_client.is_authenticated():
+            data.update(get_authorized_data(kinde_client))        
+            template = "home.html"
     return render_template(template, **data)
 
 
@@ -68,37 +74,47 @@ def register():
 @app.route("/api/auth/kinde_callback")
 def callback():
     kinde_client.fetch_token(authorization_response=request.url)
+    data = {"current_year": date.today().year}
+    data.update(get_authorized_data(kinde_client))
+    session["user"] = data.get("id")
+    user_clients[data.get("id")] = kinde_client
     return app.redirect(url_for("index"))
 
 
 @app.route("/api/auth/logout")
 def logout():
+    user_clients[session.get("user")] = None
+    session["user"] = None
     return app.redirect(
         kinde_client.logout(redirect_to=app.config["LOGOUT_REDIRECT_URL"])
     )
 
 
 @app.route("/details")
-@login_required(kinde_client)
 def get_details():
-    data = {"current_year": date.today().year}
-    data.update(get_authorized_data(kinde_client))
-    data["access_token"] = kinde_client.configuration.access_token
-    template = "details.html"
+    template = "logged_out.html"
+    if session.get("user"):
+        kinde_client = user_clients.get(session.get("user"))
+        data = {"current_year": date.today().year}
+        data.update(get_authorized_data(kinde_client))
+        data["access_token"] = kinde_client.configuration.access_token
+        template = "details.html"
     return render_template(template, **data)
 
 
 @app.route("/helpers")
-@login_required(kinde_client)
 def get_helper_functions():
-    data = {"current_year": date.today().year}
-    data.update(get_authorized_data(kinde_client))
-    data["claim"] = kinde_client.get_claim("iss")
-    data["organization"] = kinde_client.get_organization()
-    data["user_organizations"] = kinde_client.get_user_organizations()
-    data["flag"] = kinde_client.get_flag("theme")
-    data["bool_flag"] = kinde_client.get_boolean_flag("is_dark_mode")
-    data["str_flag"] = kinde_client.get_string_flag("theme")
-    data["int_flag"] = kinde_client.get_integer_flag("competitions_limit")
-    template = "helpers.html"
+    template = "logged_out.html"
+    if session.get("user"):
+        kinde_client = user_clients.get(session.get("user"))
+        data = {"current_year": date.today().year}
+        data.update(get_authorized_data(kinde_client))
+        data["claim"] = kinde_client.get_claim("iss")
+        data["organization"] = kinde_client.get_organization()
+        data["user_organizations"] = kinde_client.get_user_organizations()
+        data["flag"] = kinde_client.get_flag("theme")
+        data["bool_flag"] = kinde_client.get_boolean_flag("is_dark_mode")
+        data["str_flag"] = kinde_client.get_string_flag("theme")
+        data["int_flag"] = kinde_client.get_integer_flag("competitions_limit")
+        template = "helpers.html"
     return render_template(template, **data)

--- a/config.py
+++ b/config.py
@@ -4,11 +4,14 @@ from kinde_sdk.kinde_api_client import GrantType
 SITE_HOST = "localhost"
 SITE_PORT = "5000"
 SITE_URL = f"http://{SITE_HOST}:{SITE_PORT}"
-LOGOUT_REDIRECT_URL = f"http://{SITE_HOST}:{SITE_PORT}"
+LOGOUT_REDIRECT_URL = f"http://{SITE_HOST}:{SITE_PORT}/api/auth/logout"
 KINDE_CALLBACK_URL = f"http://{SITE_HOST}:{SITE_PORT}/api/auth/kinde_callback"
 CLIENT_ID = "CLIENT_ID"
 CLIENT_SECRET = "SOME_SECRET"
 KINDE_ISSUER_URL = "https://[your_subdomain].kinde.com"
-GRANT_TYPE = GrantType.AUTHORIZATION_CODE
-CODE_VERIFIER = "CODE_VERIFIER"
+GRANT_TYPE = GrantType.AUTHORIZATION_CODE_WITH_PKCE
+CODE_VERIFIER = "joasd923nsad09823noaguesr9u3qtewrnaio90eutgersgdsfg" # A suitably long string > 43 chars
 TEMPLATES_AUTO_RELOAD = True
+SESSION_TYPE = "filesystem"
+SESSION_PERMANENT = False
+SECRET_KEY = "joasd923nsad09823noaguesr9u3qtewrnaio90eutgersgdsfgs" # Secret used for session management

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.2.2
 kinde-python-sdk==1.2.1
+Flask-Session==0.5.0


### PR DESCRIPTION
# Explain your changes

The sample starter kit did not have any session management, and was using a single client object for all operations. This change creates a client object for each user that logs in, and uses a server side session to allow concurrent logins to work correctly.

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
