### PR TITLE
Fix issue cannot import name 'url_quote' from 'werkzeug.urls'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.2.2
 kinde-python-sdk==1.2.1
 Flask-Session==0.5.0
+Werkzeug==2.2.2


### PR DESCRIPTION
# Explain your changes

This MR fix the issue https://github.com/kinde-starter-kits/python-starter-kit/issues/13

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
