### PR TITLE
docs: update README for SDK v2 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,42 @@ Clone this repo and install dependencies by running
 ```console
 $ pip install -r requirements.txt
 ```
-The minimum required version of Python is 3.8.
+The minimum required version of Python is 3.9.
 
-Set the variables in `config.py` with the details from the Kinde `App Keys` page
+## Configuration
 
-> KINDE_ISSUER_URL - The token host value
->
-> KINDE_CALLBACK_URL - The callback URL
-> 
-> LOGOUT_REDIRECT_URL - The logout URL (after logging out)
->
-> CLIENT_ID - The client id
->
-> CLIENT_SECRET - The client secret
+This starter kit uses Kinde Python SDK v2, which simplifies the configuration by using environment variables instead of a config file.
 
-e.g.
+Create a `.env` file in the root directory with the following variables from your Kinde `App Keys` page:
 
+```env
+# Kinde Flask Starter Kit Environment Variables
+# Copy this template and fill in your actual values
+
+# Required: Your Kinde application credentials
+KINDE_CLIENT_ID=your_client_id_here
+KINDE_CLIENT_SECRET=your_client_secret_here
+KINDE_REDIRECT_URI=http://localhost:5000/callback
+KINDE_DOMAIN=https://your-subdomain.kinde.com
+
+# Optional: Management API credentials (for enhanced features)
+KINDE_MANAGEMENT_CLIENT_ID=your_management_client_id_here
+KINDE_MANAGEMENT_CLIENT_SECRET=your_management_client_secret_here
+
+# Flask configuration
+FLASK_SECRET_KEY=your-secret-key-here
 ```
-KINDE_ISSUER_URL = "https://<your_kinde_subdomain>.kinde.com"
-KINDE_CALLBACK_URL = "http://localhost:5000/api/auth/kinde_callback"
-LOGOUT_REDIRECT_URL = "http://localhost:5000"
-CLIENT_ID = "<your_kinde_client_id>"
-CLIENT_SECRET = "<your_kinde_client_secret>"
-```
+
+### Required Environment Variables:
+
+- **KINDE_CLIENT_ID** - Your Kinde client ID
+- **KINDE_CLIENT_SECRET** - Your Kinde client secret  
+- **KINDE_REDIRECT_URI** - The callback URL (typically `http://localhost:5000/callback`)
+- **KINDE_DOMAIN** - Your Kinde domain (e.g., `https://your-subdomain.kinde.com`)
+- **KINDE_MANAGEMENT_CLIENT_ID** - Your Kinde management client ID (for Management API features)
+- **KINDE_MANAGEMENT_CLIENT_SECRET** - Your Kinde management client secret
+
+> **Note**: Make sure to add `.env` to your `.gitignore` file to keep your secrets secure.
 
 ## Set your Callback and Logout URLs
 
@@ -40,17 +53,28 @@ Your user will be redirected to Kinde to authenticate. After they have logged in
 
 You need to specify in Kinde which URL you would like your user to be redirected to in order to authenticate your app.
 
-On the App Keys page set ` Allowed callback URLs` to `http://localhost:5000/api/auth/kinde_callback`
+On the App Keys page set `Allowed callback URLs` to `http://localhost:5000/callback`
 
 > Important! This is required for your users to successfully log in to your app.
 
-You will also need to set the URL they will be redirected to upon logout. Set the `Allowed logout redirect URLs` to http://localhost:5000.
+You will also need to set the URL they will be redirected to upon logout. Set the `Allowed logout redirect URLs` to `http://localhost:5000`.
 
 ## Start the app
 
 Run `flask run` and navigate to `http://localhost:5000`.
 
 Click on `Sign up` and register your first user for your business!
+
+## What's New in SDK v2
+
+This starter kit has been updated to use Kinde Python SDK v2, which includes several improvements:
+
+- **Simplified Configuration**: No more `config.py` file - everything is configured via environment variables
+- **Framework Integration**: Built-in Flask integration with automatic route registration
+- **Async Support**: Better support for asynchronous operations
+- **Management API**: Enhanced Management API client for user and organization management
+- **Feature Flags**: Improved feature flag handling
+- **Permissions**: Streamlined permission checking
 
 ## View users in Kinde
 


### PR DESCRIPTION
# Explain your changes

- Updated minimum Python requirement to 3.9
- Replaced config.py instructions with .env configuration
- Added comprehensive environment variable documentation
- Updated callback URL paths to match new SDK v2 routing
- Added 'What's New in SDK v2' section highlighting key improvements
- Provided clear setup instructions for new environment-based configuration
- Updated callback and logout URL examples to reflect current implementation
- Added security note about keeping .env file out of version control

Breaking Changes:
- Configuration now uses environment variables instead of config.py
- Callback URL changed from /api/auth/kinde_callback to /callback
- Minimum Python version increased from 3.8 to 3.9

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
